### PR TITLE
patch: fix "strict mode" error when getting prefix on short string

### DIFF
--- a/src/Core/Value.php
+++ b/src/Core/Value.php
@@ -34,6 +34,9 @@ class Value
     public function getStringPrefix(): string
     {
         $str = $this->value;
+        if (strlen($str) < 2) {
+            return '';
+        }
         return $str[0] . $str[1];
     }
 

--- a/src/DataTypes/JsonString.php
+++ b/src/DataTypes/JsonString.php
@@ -7,6 +7,9 @@ class JsonString
     // encodeStr
     public static function encodeString(string $str): string
     {
+        if (strlen($str) < 2) {
+            return $str;
+        }
         $prefix = $str[0] . $str[1];
         switch ($prefix) {
             case 'b|':
@@ -22,6 +25,9 @@ class JsonString
     // decodeStr
     public static function decodeString(string $str): string
     {
+        if (strlen($str) < 2) {
+            return $str;
+        }
         $prefix = $str[0] . $str[1];
         return $prefix === 's|' ? substr($str, 2) : $str;
     }

--- a/tests/CompressJsonBaseTest.php
+++ b/tests/CompressJsonBaseTest.php
@@ -100,4 +100,21 @@ class CompressJsonBaseTest extends TestCase
         // Assert
         $this->assertEquals($data, $decompressed);
     }
+
+    public function testShortString()
+    {
+        $data = [
+            '',
+            'p',
+            'pp'
+        ];
+        $compressed = Compressor::create()
+            ->compress($data);
+        $compressedJson = $compressed
+            ->toJson();
+        $decompressed = Compressor::create()
+            ->decompressJson($compressedJson);
+        // Assert
+        $this->assertEquals($data, $decompressed);
+    }
 }


### PR DESCRIPTION
The original code get the first 2 characters from a string to check for the encoding prefix. However sometime the string is shorter than 2. It will raise error in "strict mode".

This pull request resolved the issue reported in https://github.com/inkrot/php-compress-json/issues/1