### PR TITLE
patch: fix numeric type judgment error

### DIFF
--- a/src/DataTypes/JsonObject.php
+++ b/src/DataTypes/JsonObject.php
@@ -10,7 +10,7 @@ class JsonObject
 
     private static function decodeKey(string $key): int
     {
-        return is_numeric($key) ? $key : JsonNumber::s_to_int($key);
+        return is_int($key) ? $key : JsonNumber::s_to_int($key);
     }
 
     /**

--- a/tests/CompressJsonBaseTest.php
+++ b/tests/CompressJsonBaseTest.php
@@ -117,4 +117,17 @@ class CompressJsonBaseTest extends TestCase
         // Assert
         $this->assertEquals($data, $decompressed);
     }
+
+    public function testSecondValueAsNumericalString()
+    {
+        //raw json
+        $rawJson = '["0","1","2","3","4","5","6","7","8","9",{"A":"h"},{"B":"c"},{"C":"E"},{"D":"b"},{"E":"L"},{"F":"S"},{"G":"C"},{"H":"G"},{"I":"L"},{"J":"I"},{"K":"R"},{"L":"l"},{"M":"6"},{"N":"I"},{"O":"k"}]';
+        //compress-json.js generated compressed json
+        $compressedJson = '[["0","1","2","3","4","5","6","7","8","9","A","a|A","h","o|B|C","B","a|E","c","o|F|G","C","a|I","E","o|J|K","D","a|M","b","o|N|O","a|K","L","o|Q|R","F","a|T","S","o|U|V","G","a|X","o|Y|I","H","a|a","o|b|X","I","a|d","o|e|R","J","a|g","o|h|d","K","a|j","R","o|k|l","a|R","l","o|n|o","M","a|q","o|r|6","N","a|t","o|u|d","O","a|w","k","o|x|y","a|0|1|2|3|4|5|6|7|8|9|D|H|L|P|S|W|Z|c|f|i|m|p|s|v|z"],"10"]';
+        $data=json_decode($rawJson,true);
+        $decompressed = Compressor::create()
+            ->decompressJson($compressedJson);
+        // Assert
+        $this->assertEquals($data, $decompressed);
+    }
 }


### PR DESCRIPTION
When using `compress-json` on the frontend to compress a JSON structure and sending it to a PHP backend for decompression, the decompression fails under certain conditions.

The issue arises because the compressed JSON array contains string values representing numbers `(e.g., "123")`, and the current implementation uses `is_numeric()` in `JsonObject` to determine whether a value is a key reference. However, `is_numeric()` returns true for numeric strings, which causes a misinterpretation of actual string values as references.

Replacing `is_numeric()` with `is_int()` resolves the issue, as it correctly distinguishes between numeric strings and integer keys.

This change ensures proper handling of numeric string values and maintains compatibility with the compression format.

case:
**raw json：**
`[{"test_paper_id":1,"test_question_id":1,"sort":0,"score":0,"is_required":0,"status":1,"type":1,"title":"hello1","content":[{"number":"A","content":"hello1-item-1","score":10,"is_show_input":false,"isCheck":false},{"number":"B","content":"hello1-item-2","score":0,"is_show_input":false,"isCheck":false},{"number":"C","content":"hello1-item-3","score":0,"is_show_input":false,"isCheck":true},{"number":"D","content":"hello1-item-4","score":0,"is_show_input":false,"isCheck":false}],"right_answer":"A","inputContent":"","user_answer":["B"]},{"test_paper_id":1,"test_question_id":1,"sort":0,"score":0,"is_required":0,"status":1,"type":1,"title":"hello2","content":[{"number":"A","content":"hello2-item-1","score":10,"is_show_input":false,"isCheck":false},{"number":"B","content":"hello2-item-2","score":0,"is_show_input":false,"isCheck":false},{"number":"C","content":"hello2-item-3","score":0,"is_show_input":false,"isCheck":true},{"number":"D","content":"hello2-item-4","score":0,"is_show_input":false,"isCheck":false}],"right_answer":"A","inputContent":"","user_answer":["C"]},{"test_paper_id":1,"test_question_id":1,"sort":0,"score":0,"is_required":0,"status":1,"type":1,"title":"hello3","content":[{"number":"A","content":"hello3-item-1","score":10,"is_show_input":false,"isCheck":false},{"number":"B","content":"hello3-item-2","score":0,"is_show_input":false,"isCheck":false},{"number":"C","content":"hello3-item-3","score":0,"is_show_input":false,"isCheck":true},{"number":"D","content":"hello3-item-4","score":0,"is_show_input":false,"isCheck":false}],"right_answer":"A","inputContent":"","user_answer":["C"]}]`

**compress-json.js generated compressed json**
`[["test_paper_id","test_question_id","sort","score","is_required","status","type","title","content","right_answer","inputContent","user_answer","a|0|1|2|3|4|5|6|7|8|9|A|B","n|1","n|0","hello1","number","is_show_input","isCheck","a|G|8|3|H|I","A","hello1-item-1","n|A","b|F","o|J|K|L|M|N|N","B","hello1-item-2","o|J|P|Q|E|N|N","C","hello1-item-3","b|T","o|J|S|T|E|N|U","D","hello1-item-4","o|J|W|X|E|N|N","a|O|R|V|Y","","a|P","o|C|D|D|E|E|E|D|D|F|Z|K|a|b","hello2","hello2-item-1","o|J|K|e|M|N|N","hello2-item-2","o|J|P|g|E|N|N","hello2-item-3","o|J|S|i|E|N|U","hello2-item-4","o|J|W|k|E|N|N","a|f|h|j|l","a|S","o|C|D|D|E|E|E|D|D|d|m|K|a|n","hello3","hello3-item-1","o|J|K|q|M|N|N","hello3-item-2","o|J|P|s|E|N|N","hello3-item-3","o|J|S|u|E|N|U","hello3-item-4","o|J|W|w|E|N|N","a|r|t|v|x","o|C|D|D|E|E|E|D|D|p|y|K|a|n","a|c|o|z"],"10"]`